### PR TITLE
Reflect API changes in progression translator.

### DIFF
--- a/src/Destiny/Support/Translators/ProgressionTranslator.php
+++ b/src/Destiny/Support/Translators/ProgressionTranslator.php
@@ -40,11 +40,14 @@ class ProgressionTranslator implements Translates
         'queen'                         => 'r1_s3_factions_queen',
         'superior_gear_material_source' => 'superior_gear_material_source',
         'terminals'                     => 'terminals',
-        'trials_of_osiris_wins'         => 'r1_s3_tickets.pvp.trials_of_osiris.wins',
-        'trials_of_osiris_losses'       => 'r1_s3_tickets.pvp.trials_of_osiris.losses',
+        'trials_of_osiris_wins'         => 'r1_s4_tickets.pvp.trials_of_osiris.wins',
+        'trials_of_osiris_losses'       => 'r1_s4_tickets.pvp.trials_of_osiris.losses',
         'weekly_pve'                    => 'weekly_pve',
         'weekly_pvp'                    => 'weekly_pvp',
         'test_faction'                  => 'test_faction',
+        'character_gear_tilt'           => 'character_gear_tilt',
+        'gunsmith'                      => 'r1_s4_factions_gunsmith',
+        'hiveship_orbs'                 => 'r1_s4_hiveship_orbs',
     ];
 
     /**


### PR DESCRIPTION
API changes have resulted in `ProgressionNotFoundException` raised when getting character data.

* New progression properties of `character_gear_tilt`, `r1_s4_factions_gunsmith` and `r1_s4_hiveship_orbs`
* The `r1_s3` properties for Trials now appears to be `r1_s4`.